### PR TITLE
Enable use of the watchdog

### DIFF
--- a/app/pump_control.py
+++ b/app/pump_control.py
@@ -42,8 +42,11 @@ epin = usb.util.find_descriptor(
 
 assert epin is not None
 
-for x in range(0,100):
+import datetime
+
+while True:
 # write the data
+    print(datetime.datetime.now())
     ep.write(b'\x01\x01\x01')
     print("wrote both pumps on")
     print(epin.read(64))


### PR DESCRIPTION
- Changes some of the LED state, so its obvious when USB is doing
things vs not (blue flickers off on command)

- New green state for power but no USB

- Watchdog and BOD33 is enabled in firmware (Fixes #8)